### PR TITLE
Custom CSS section and Mobile Dropdown Menu Issue fixed

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -20,6 +20,17 @@
         }
     );
 
+    // toggle mobile dropdown menu after click menu item link
+    if ( jQuery( '#nav-toggle:visible' ).length > 0 ) {
+        jQuery( '.onepress-menu a' ).on( 'click', function () {
+            var $om = jQuery( '.onepress-menu' );
+            if ( ! $om.hasClass( 'onepress-menu-mobile' ) ) return false;
+            $om.slideUp( function () {
+                jQuery( '#nav-toggle' ).click();
+            } );
+        } );
+    }
+
 } )();
 
 /**

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -470,7 +470,6 @@ function onepress_customize_register( $wp_customize ) {
 				'onepress_hero_option_animation',
 				array(
 					'default'              => 'flipInX',
-					'capability'           => 'edit_themes',
 					'sanitize_callback'    => 'sanitize_text_field',
 				)
 			);


### PR DESCRIPTION
1. Fixed no Custom CSS section under Theme Options when defined DISALLOW_FILE_EDIT == true.
2. Fixed issue 103: Now mobile menu will close(slideUp) when clicked on any menu link.