### PR TITLE
Add hook `onepress_after_site_end`

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -67,6 +67,8 @@ do_action( 'onepress_site_end' );
 ?>
 </div><!-- #page -->
 
+<?php do_action( 'onepress_after_site_end' ); ?>
+
 <?php wp_footer(); ?>
 
 </body>


### PR DESCRIPTION
See this topic: https://wordpress.org/support/topic/two-row-menu-title/

Since my plugin Off-Canvas Sidebars was recommended by the author it thought to create this PR to allow your users to implement the correct hooks without modifications to the theme.