### PR TITLE
Removed Template literals in theme.js

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -140,14 +140,14 @@ function _to_bool(v) {
 		let vh = window.innerHeight * 0.01;
 		let vw = window.innerWidth * 0.01;
 		// Then we set the value in the --vh, --vw custom property to the root of the document
-		document.documentElement.style.setProperty("--vh", `${vh}px`);
-		document.documentElement.style.setProperty("--vw", `${vw}px`);
+		document.documentElement.style.setProperty("--vh", vh + "px");
+		document.documentElement.style.setProperty("--vw", vw + "px");
 
 		window.addEventListener("resize", function() {
 			let vh = window.innerHeight * 0.01;
 			let vw = window.innerWidth * 0.01;
-			document.documentElement.style.setProperty("--vh", `${vh}px`);
-			document.documentElement.style.setProperty("--vw", `${vw}px`);
+			document.documentElement.style.setProperty("--vh", vh + "px");
+			document.documentElement.style.setProperty("--vw", vw + "px");
 		});
 	}
 })();


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals Internet Explorer does not support Template literals in JavaScript Code. The usage of the template literals causes an error when using Internet Explorer 11 (the hero image doesn't load).
Removed usage of Template literals in the file theme.js