### PR TITLE
Add support for wp_body_open

### DIFF
--- a/header.php
+++ b/header.php
@@ -19,6 +19,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php do_action( 'wp_body_open' ); ?>
 <?php do_action( 'onepress_before_site_start' ); ?>
 <div id="page" class="hfeed site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'onepress' ); ?></a>


### PR DESCRIPTION
WP 5.2 introduced a new `wp_body_open()` function that is used to trigger a `wp_body_open` action. This action is intended to allow developers to inject code immediately following the opening `<body>` tag.